### PR TITLE
High Quality Youtube Playback

### DIFF
--- a/process.py
+++ b/process.py
@@ -166,9 +166,8 @@ def playWithOMX(url, sub, width="", height="", new_log=False):
             str(volume) + " < /tmp/cmd"
         )
     if "/tmp/" in url:
-        os.system(
-            "rm -rf " + url
-        )
+        if os.path.exists(url):
+            os.remove(url)
 
     if getState() != "2":  # In case we are again in the launchvideo function
         setState("0")

--- a/process.py
+++ b/process.py
@@ -91,10 +91,17 @@ Extracting url in maximal quality.''')
             vidId = ''.join(random.choice(
                 string.ascii_uppercase + string.digits) for _ in range(6)
             )
-            os.system(
-                "youtube-dl -f 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/bestvideo+bestaudio' -o /tmp/" +
-                vidId + ".mp4 --merge-output-format mp4 " + url
+            ydl = youtube_dl.YoutubeDL(
+                {
+                    'logger': logger,
+                    'format': 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/bestvideo+bestaudio/best',
+                    'ignoreerrors': True,
+                    'merge_output_format': 'mp4',
+                    'outtmpl': '/tmp/' + vidId + '.mp4'
+                }
             )
+            with ydl:  # Downloading youtub-dl video
+                result = ydl.download([url])
             return "/tmp/" + vidId + ".mp4"
     elif "vimeo" in url:
         if slow_mode:

--- a/process.py
+++ b/process.py
@@ -3,6 +3,8 @@ import os
 import threading
 import logging
 import json
+import random
+import string
 logger = logging.getLogger("RaspberryCast")
 volume = 0
 
@@ -86,14 +88,14 @@ def return_full_url(url, sub=False, slow_mode=False):
         else:
             logger.debug('''CASTING: Youtube link detected.
 Extracting url in maximal quality.''')
-            for fid in ('22', '18', '36', '17'):
-                for i in video['formats']:
-                    if i['format_id'] == fid:
-                        logger.debug(
-                            'CASTING: Playing highest video quality ' +
-                            i['format_note'] + '(' + fid + ').'
-                        )
-                        return i['url']
+            vidId = ''.join(random.choice(
+                string.ascii_uppercase + string.digits) for _ in range(6)
+            )
+            os.system(
+                "youtube-dl -f 'bestvideo[ext=mp4]+bestaudio[ext=m4a]/bestvideo+bestaudio' -o /tmp/" +
+                vidId + ".mp4 --merge-output-format mp4 " + url
+            )
+            return "/tmp/" + vidId + ".mp4"
     elif "vimeo" in url:
         if slow_mode:
             for i in video['formats']:
@@ -162,6 +164,10 @@ def playWithOMX(url, sub, width="", height="", new_log=False):
         os.system(
             "omxplayer -b -r -o both '" + url + "' " + resolution + " --vol " +
             str(volume) + " < /tmp/cmd"
+        )
+    if "/tmp/" in url:
+        os.system(
+            "rm -rf " + url
         )
 
     if getState() != "2":  # In case we are again in the launchvideo function


### PR DESCRIPTION
The way Youtube delivers media files now is by splitting them up into 2
separate streams of audio only and video only. Unfortunately, it isn't
possible to get a fully muxed stream that has decent quality anymore.

I attempted to mux using ffmpeg, but the speed was nowhere near
sufficient to give a smooth stream. In the end, the only option that
really worked out is have Youtube-dl download the video and audio, mux
it into a local file and then have omxplayer play this file.

The video file gets removed as soon as playback is finished as to not
cause hard drive clutter on already limited space like an RPi.